### PR TITLE
[7] Enables ui to distinguish between two flavours of Czech dictionary

### DIFF
--- a/bez_diakritiky/manifest.json
+++ b/bez_diakritiky/manifest.json
@@ -10,6 +10,6 @@
   "version": "1.1.2",
   "author": "Mozilla.cz",
   "dictionaries": {
-    "cs": "dictionaries/Cestina.dic"
+    "cs-Cestina": "dictionaries/Cestina.dic"
   }
 }


### PR DESCRIPTION
Both dictionaries cannot have the "cs" code becasue Firefox translates
that to "Czech" and they both overlap in UI. This commit adds
a qualifier "Cestina" akin to English (United States), making it
Czech (Cestina). 

fixes #7 